### PR TITLE
Create a separate message for each consumption.

### DIFF
--- a/src/Savorboard.CAP.InMemoryMessageQueue/InMemoryConsumerClient.cs
+++ b/src/Savorboard.CAP.InMemoryMessageQueue/InMemoryConsumerClient.cs
@@ -37,7 +37,7 @@ namespace Savorboard.CAP.InMemoryMessageQueue
             {
                 _queue.Subscribe(_groupId, OnConsumerReceived, topic);
 
-                _logger.LogInformation($"InMemory message queue initialize the topic: {topic}");
+                _logger.LogInformation($"InMemory message queue initialize the topic: {_groupId} {topic}");
             }
         }
 


### PR DESCRIPTION
Prevent conflicts at the time of consumption.